### PR TITLE
add encoding setting in rails_guides/helpers.rb

### DIFF
--- a/rails_guides/helpers.rb
+++ b/rails_guides/helpers.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'yaml'
 
 module RailsGuides


### PR DESCRIPTION
this file has Chinese characters, don't you get the error when you `rake` sth?
