### PR TITLE
fix 404 errors in links

### DIFF
--- a/source/zh-CN/command_line.md
+++ b/source/zh-CN/command_line.md
@@ -400,7 +400,7 @@ Database schema version   20110805173523
 
 Rake 命名空间 `db:` 中最常用的任务是 `migrate` 和 `create`，这两个任务会尝试运行所有迁移相关的 Rake 任务（`up`，`down`，`redo`，`reset`）。`rake db:version` 在排查问题时很有用，会输出数据库的当前版本。
 
-关于数据库迁移的更多介绍，参阅“[Active Record 数据库迁移](migrations.html)”一文。
+关于数据库迁移的更多介绍，参阅“[Active Record 数据库迁移](active_record_migrations.html)”一文。
 
 ### `doc`
 

--- a/source/zh-CN/getting_started.md
+++ b/source/zh-CN/getting_started.md
@@ -459,7 +459,7 @@ end
 
 在这个迁移中定义了一个名为 `change` 的方法，在运行迁移时执行。`change` 方法中定义的操作都是可逆的，Rails 知道如何撤销这次迁移操作。运行迁移后，会创建 `articles` 表，以及一个字符串字段和文本字段。同时还会创建两个时间戳字段，用来跟踪记录的创建时间和更新时间。
 
-TIP: 关于迁移的详细说明，请参阅“[Active Record 数据库迁移](/migrations.html)”一文。
+TIP: 关于迁移的详细说明，请参阅“[Active Record 数据库迁移](active_record_migrations.html)”一文。
 
 然后，使用 rake 命令运行迁移：
 


### PR DESCRIPTION
原文的Active Record Migrations url是http://guides.rubyonrails.org/v4.1/migrations.html， 而Ruby China的是http://guides.ruby-china.org/active_record_migrations.html， 修正404错误