### PR TITLE
译稿升级到 Rails 5.1.3

### DIFF
--- a/source/zh-CN/initialization.md
+++ b/source/zh-CN/initialization.md
@@ -97,7 +97,7 @@ require 'bundler/setup' # 设置 Gemfile 中列出的所有 gem
 *   arel
 *   builder
 *   bundler
-*   erubis
+*   erubi
 *   i18n
 *   mail
 *   mime-types

--- a/source/zh-CN/upgrading_ruby_on_rails.md
+++ b/source/zh-CN/upgrading_ruby_on_rails.md
@@ -81,7 +81,7 @@ Rails 5.1 的变动参见[发布记](5_1_release_notes.html)。
 
 如果你的应用使用顶层 `HashWithIndifferentAccess` 类，应该逐渐转用 `ActiveSupport::HashWithIndifferentAccess` 类。
 
-这只是一项温和的弃用，目前代码不受影响，也不看看到提醒，但是以后会删除这个常量。
+这只是一项温和的弃用，目前代码不受影响，也不会看到提醒，但是以后会删除这个常量。
 
 此外，如果 YAML 文档转储中包含这个类的对象，要重新加载并转储，以便引用正确的常量，防止以后无法加载。
 


### PR DESCRIPTION
只更新了译稿，如其他代码需要更新，请相应修改。